### PR TITLE
Fix CouponCard visuals

### DIFF
--- a/src/components/CouponCard.jsx
+++ b/src/components/CouponCard.jsx
@@ -1,7 +1,7 @@
 // File: /src/components/CouponCard.jsx
 
 import React, { useState } from 'react';
-import { motion } from 'framer-motion';
+import { motion as Motion } from 'framer-motion';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import slugify from '../utils/slugify.js';
@@ -12,12 +12,12 @@ export default function CouponCard({ title, image, caption, qrCode }) {
   const slug = slugify(title);
 
   return (
-    <motion.div
+    <Motion.div
       whileHover={{ scale: 1.03 }}
       whileTap={{ scale: 0.97 }}
-      className="w-full max-w-sm h-[430px] perspective rounded-2xl"
+      className="relative w-full max-w-sm h-[430px] perspective rounded-2xl pb-8 z-10"
     >
-      <motion.div
+      <Motion.div
         onClick={() => setFlipped(!flipped)}
         className={`relative w-full h-full cursor-pointer transition-transform duration-700 preserve-3d ${flipped ? 'rotate-y-180' : ''}`}
       >
@@ -26,7 +26,7 @@ export default function CouponCard({ title, image, caption, qrCode }) {
           <img
             src={image}
             alt={title}
-            className="w-32 h-32 rounded-xl object-contain object-center mb-4 border border-pink-200 shadow"
+            className="w-full h-full max-h-56 object-contain object-center mb-4 rounded-xl border border-pink-200 shadow pointer-events-none"
           />
           <h2 className="text-xl font-display font-bold text-rose-700 drop-shadow">
             {title}
@@ -49,8 +49,8 @@ export default function CouponCard({ title, image, caption, qrCode }) {
             </Link>
           )}
         </div>
-      </motion.div>
-    </motion.div>
+      </Motion.div>
+    </Motion.div>
   );
 }
 


### PR DESCRIPTION
## Summary
- ensure coupon card image fills without cropping
- rename framer-motion import to avoid ESLint error
- add padding/z-index so Next button remains tappable
- disable pointer events on card image

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6854587fcf7c8332a3f64a1b0b3e359f