### PR TITLE
Improve coupon navigation and styling

### DIFF
--- a/src/components/CouponCard.jsx
+++ b/src/components/CouponCard.jsx
@@ -6,8 +6,9 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import slugify from '../utils/slugify.js';
 
-export default function CouponCard({ title, image, caption, qrCode }) {
+export default function CouponCard({ title, image, caption, qrCode, showInstruction }) {
   const [flipped, setFlipped] = useState(false);
+  const [hintHidden, setHintHidden] = useState(false);
 
   const slug = slugify(title);
 
@@ -18,7 +19,10 @@ export default function CouponCard({ title, image, caption, qrCode }) {
       className="relative w-full max-w-sm h-[430px] perspective rounded-2xl pb-8 z-10"
     >
       <Motion.div
-        onClick={() => setFlipped(!flipped)}
+        onClick={() => {
+          setFlipped(!flipped);
+          setHintHidden(true);
+        }}
         className={`relative w-full h-full cursor-pointer transition-transform duration-700 preserve-3d ${flipped ? 'rotate-y-180' : ''}`}
       >
         {/* Front */}
@@ -31,6 +35,11 @@ export default function CouponCard({ title, image, caption, qrCode }) {
           <h2 className="text-xl font-display font-bold text-rose-700 drop-shadow">
             {title}
           </h2>
+          {showInstruction && !flipped && !hintHidden && (
+            <div className="absolute bottom-4 left-1/2 -translate-x-1/2 bg-black/60 text-white text-sm px-3 py-1 rounded pointer-events-none">
+              Tap image for QR code
+            </div>
+          )}
         </div>
 
         {/* Back */}
@@ -40,7 +49,11 @@ export default function CouponCard({ title, image, caption, qrCode }) {
           </p>
 
           {qrCode && (
-            <Link to={`/redeem/${slug}`} className="mt-5 block">
+            <Link
+              to={`/redeem/${slug}`}
+              className="mt-5 block"
+              onClick={(e) => e.stopPropagation()}
+            >
               <img
                 src={qrCode}
                 alt={`QR Code for ${title}`}
@@ -59,4 +72,5 @@ CouponCard.propTypes = {
   image: PropTypes.string.isRequired,
   caption: PropTypes.string,
   qrCode: PropTypes.string,
+  showInstruction: PropTypes.bool,
 };

--- a/src/components/CouponGrid.jsx
+++ b/src/components/CouponGrid.jsx
@@ -20,13 +20,14 @@ export default function CouponGrid() {
         image={current.image}
         caption={current.caption}
         qrCode={current.qrCode}
+        showInstruction={index > 0}
       />
       {coupons.length > 1 && (
         <button
           onClick={nextCoupon}
-          className="mt-6 px-4 py-2 bg-rose-600 text-white rounded shadow"
+          className="fixed bottom-4 right-4 px-4 py-2 bg-black text-white rounded-full shadow-lg"
         >
-          Next
+          Next Coupon
         </button>
       )}
     </div>

--- a/src/components/Redeem.jsx
+++ b/src/components/Redeem.jsx
@@ -1,13 +1,18 @@
 // File: /src/components/Redeem.jsx
 
 import React from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import slugify from '../utils/slugify.js';
 import coupons from '../data/coupons';
 
 export default function Redeem() {
   const { slug } = useParams();
-  const coupon = coupons.find((c) => slugify(c.title) === slug);
+  const navigate = useNavigate();
+  const index = coupons.findIndex((c) => slugify(c.title) === slug);
+  const coupon = coupons[index];
+  const nextSlug = coupons[(index + 1) % coupons.length]
+    ? slugify(coupons[(index + 1) % coupons.length].title)
+    : null;
 
   if (!coupon) {
     return (
@@ -21,9 +26,25 @@ export default function Redeem() {
     <div className="min-h-screen bg-rose-50 flex flex-col items-center justify-center text-center p-6">
       <img src={coupon.image} alt={coupon.title} className="w-64 h-64 object-contain object-center rounded-xl shadow border mb-6" />
       <h1 className="text-4xl font-display text-rose-700 mb-4">{coupon.title}</h1>
-      <p className="text-lg font-handwriting text-gray-800 max-w-md italic">
+      <p className="text-lg font-handwriting text-gray-800 max-w-md italic mb-8">
         {coupon.caption}
       </p>
+      <div className="flex gap-4">
+        <button
+          onClick={() => navigate(-1)}
+          className="px-4 py-2 bg-black text-white rounded shadow"
+        >
+          Back
+        </button>
+        {nextSlug && (
+          <button
+            onClick={() => navigate(`/redeem/${nextSlug}`)}
+            className="px-4 py-2 bg-rose-600 text-white rounded shadow"
+          >
+            Next Coupon
+          </button>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- show an instruction overlay for QR code on later coupons
- keep card from flipping when tapping the QR link
- add a fixed bottom-right "Next Coupon" button
- offer Back/Next navigation on redeem pages

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685461fff6e883329530a34b258fc3e4