### PR TITLE
Add banner overlay for coupon types

### DIFF
--- a/src/components/CouponCard.jsx
+++ b/src/components/CouponCard.jsx
@@ -6,7 +6,14 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import slugify from '../utils/slugify.js';
 
-export default function CouponCard({ title, image, caption, qrCode, showInstruction }) {
+export default function CouponCard({
+  title,
+  image,
+  caption,
+  qrCode,
+  couponType,
+  showInstruction,
+}) {
   const [flipped, setFlipped] = useState(false);
   const [hintHidden, setHintHidden] = useState(false);
 
@@ -27,6 +34,16 @@ export default function CouponCard({ title, image, caption, qrCode, showInstruct
       >
         {/* Front */}
         <div className="absolute w-full h-full backface-hidden flex flex-col items-center justify-center p-4 text-center bg-white/90 rounded-2xl shadow-md border border-pink-300">
+          {couponType && (
+            <Motion.div
+              initial={{ opacity: 0, y: -10 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5 }}
+              className="pointer-events-none absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-gradient-to-r from-rose-500 via-pink-600 to-rose-500 text-white font-display font-bold text-sm px-4 py-1 rounded-full shadow-lg backdrop-blur-sm z-20"
+            >
+              This coupon is valid for: {couponType}
+            </Motion.div>
+          )}
           <img
             src={image}
             alt={title}
@@ -72,5 +89,6 @@ CouponCard.propTypes = {
   image: PropTypes.string.isRequired,
   caption: PropTypes.string,
   qrCode: PropTypes.string,
+  couponType: PropTypes.string,
   showInstruction: PropTypes.bool,
 };

--- a/src/components/CouponGrid.jsx
+++ b/src/components/CouponGrid.jsx
@@ -20,6 +20,7 @@ export default function CouponGrid() {
         image={current.image}
         caption={current.caption}
         qrCode={current.qrCode}
+        couponType={current.couponType}
         showInstruction={index > 0}
       />
       {coupons.length > 1 && (

--- a/src/data/coupons.js
+++ b/src/data/coupons.js
@@ -6,48 +6,64 @@ const coupons = [
     image: "/assets/sancha-duty-i.png",
     caption: "One walk, bath, or nail-trim for our little loaf.",
     qrCode: "/qr/sancha-duty-i.png",
+    couponType:
+      "I will handle one dog-related task: walk, bathe, clean, or clip — no questions asked. 🐶🛁",
   },
   {
     title: "Sancha Duty II",
     image: "/assets/sancha-duty-ii.png",
     caption: "A second helping of fuzzy devotion for our princess.",
     qrCode: "/qr/sancha-duty-ii.png",
+    couponType:
+      "You name the Sancha service, I provide it — no delay, no protest, no shortcuts. 🐾🧼",
   },
   {
     title: "Massage I (Jezzah Edition)",
     image: "/assets/massage-i-jezzah.png",
     caption: "A long back massage while Jezzah supervises (and judges).",
     qrCode: "/qr/massage-i-jezzah-edition.png",
+    couponType:
+      "A sensual massage in the style of Jezzah — complete with oils, atmosphere, and quiet devotion. ✨",
   },
   {
     title: "Massage II – Boo Boo",
     image: "/assets/massage-ii-boo-boo.png",
     caption: "A stress-melting rubdown designed for maximum Boo Boo release.",
     qrCode: "/qr/massage-ii---boo-boo.png",
+    couponType:
+      "This massage comes with Boo Boo flare — dramatic moaning optional, pure love guaranteed. 🎭💆‍♂️",
   },
   {
     title: "Movie Night I",
     image: "/assets/movie-night-i.png",
     caption: "A cozy movie night in our booth — snacks included.",
     qrCode: "/qr/movie-night-i.png",
+    couponType:
+      "We’ll watch a movie of your choice — I won’t interrupt, scroll, or second-screen. 🎬❤️",
   },
   {
     title: "Movie Night II",
     image: "/assets/movie-night-ii.png",
     caption: "An encore! Any movie, any mood, all you.",
     qrCode: "/qr/movie-night-ii.png",
+    couponType:
+      "You pick the film, I bring the snacks, and my phone stays down. Movie night, your rules. 🍿📴",
   },
   {
     title: "Park Date",
     image: "/assets/park-date.png",
     caption: "Let’s escape to the trees and just exist together.",
     qrCode: "/qr/park-date.png",
+    couponType:
+      "One intentional date at the park — I’ll plan, pack, and be fully present. No phones, just us. 🌳❤️",
   },
   {
     title: "Dinner By My Hands",
     image: "/assets/dinner-by-my-hands.png",
     caption: "A hand-cooked dinner by your personal man chef.",
     qrCode: "/qr/dinner-by-my-hands.png",
+    couponType:
+      "I will cook and serve you a full dinner by my hands — no help, no cheating, and no shortcuts. 🍽️",
   },
   {
     title: "HRV",


### PR DESCRIPTION
## Summary
- add `couponType` descriptions to `coupons.js`
- show banner text on CouponCard front using framer-motion
- pass new prop from CouponGrid

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6854638fa9bc8332a6da1d3f5d422c8e