### PR TITLE
Fix Next button layering and banner placement

### DIFF
--- a/src/components/CouponCard.jsx
+++ b/src/components/CouponCard.jsx
@@ -39,7 +39,7 @@ export default function CouponCard({
               initial={{ opacity: 0, y: -10 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.5 }}
-              className="pointer-events-none absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-gradient-to-r from-rose-500 via-pink-600 to-rose-500 text-white font-display font-bold text-sm px-4 py-1 rounded-full shadow-lg backdrop-blur-sm z-20"
+              className="pointer-events-none absolute top-6 left-1/2 -translate-x-1/2 bg-gradient-to-r from-rose-500 to-pink-600 text-white rounded-full px-6 py-2 shadow-lg backdrop-blur-sm z-30"
             >
               This coupon is valid for: {couponType}
             </Motion.div>

--- a/src/components/CouponGrid.jsx
+++ b/src/components/CouponGrid.jsx
@@ -26,7 +26,7 @@ export default function CouponGrid() {
       {coupons.length > 1 && (
         <button
           onClick={nextCoupon}
-          className="fixed bottom-4 right-4 px-4 py-2 bg-black text-white rounded-full shadow-lg"
+          className="fixed bottom-4 right-4 z-50 px-4 py-2 bg-black text-white rounded-full shadow-lg"
         >
           Next Coupon
         </button>


### PR DESCRIPTION
## Summary
- keep Next Coupon button above flipping cards
- place coupon banner in a smaller top position with gradients

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68546b8869648332b181170f888b26df